### PR TITLE
New device type support (SPH inverters)

### DIFF
--- a/.homeychangelog.json
+++ b/.homeychangelog.json
@@ -7,5 +7,8 @@
   },
   "1.1.0": {
     "en": "renamed custom capabilities in order to have auto generated flow triggers"
+  },
+  "1.2.0": {
+    "en": "New device support added"
   }
 }

--- a/drivers/growatt/api.ts
+++ b/drivers/growatt/api.ts
@@ -114,23 +114,25 @@ export class GrowattAPI {
     }
   }
 
+  /*
+    mix type seems to be working for SPH inverters
+  */
   async fetchMixData(id: string, plantId: string) {
     const statusData = (await this.request.post(`/panel/mix/getMIXStatusData?plantId=${plantId}`, `mixSn=${id}`)).data.obj;
     const totalData = (await this.request.post(`/panel/mix/getMIXTotalData?plantId=${plantId}`, `mixSn=${id}`)).data.obj;
     const plantData = (await this.request.post('/device/getPlantTotalData', `plantId=${plantId}`)).data.obj;
-    if (statusData) {
-    // if (statusData && totalData && plantData) {
+    if (statusData && totalData && plantData) {
       return {
         power: parseFloat(statusData.pLocalLoad),
         solarPower: parseFloat(statusData.pPv1),
-        batteryPower: 0,
+        batteryPower: parseFloat(statusData.pdisCharge1),
         gridPower: parseFloat(statusData.pactouser),
-        energy: 0,
-        solarEnergy: 0,
-        batteryEnergy: 0,
-        gridEnergy: 0,
-        monthlySavings: 0,
-        totalSavings: 0,
+        energy: parseFloat(totalData.elocalLoadToday),
+        solarEnergy: parseFloat(totalData.epvToday),
+        batteryEnergy: parseFloat(totalData.edischarge1Today),
+        gridEnergy: parseFloat(totalData.elocalLoadToday),
+        monthlySavings: 0, // doesn't seem to be available
+        totalSavings: 0, // doesn't seem to be available
         batterySOC: parseFloat(statusData.SOC)
       }
     }

--- a/drivers/growatt/api.ts
+++ b/drivers/growatt/api.ts
@@ -62,6 +62,9 @@ export class GrowattAPI {
     return devices;
   }
 
+  /*
+    here we get deviceType = mix... and this is build only for storage...
+  */
   async getDevicesByPlant(plant: GrowattPlant): Promise<GrowattDevice[]> {
     const devices: GrowattDevice[] = [];
     const response = (await this.request.post('panel/getDevicesByPlant', `plantId=${plant.id}`)).data;
@@ -83,6 +86,8 @@ export class GrowattAPI {
       case 'storage':
         return this.fetchStorageData(data.id, data.plantId);
         break;
+      case 'mix':
+        return this.fetchMixData(data.id, data.plantId);
       default:
         throw new Error('Inverter type not supported yet!');
     }
@@ -105,6 +110,28 @@ export class GrowattAPI {
         monthlySavings: parseFloat(plantData.mMonth),
         totalSavings: parseFloat(plantData.mTotal),
         batterySOC: parseFloat(statusData.capacity)
+      }
+    }
+  }
+
+  async fetchMixData(id: string, plantId: string) {
+    const statusData = (await this.request.post(`/panel/mix/getMIXStatusData?plantId=${plantId}`, `mixSn=${id}`)).data.obj;
+    const totalData = (await this.request.post(`/panel/mix/getMIXTotalData?plantId=${plantId}`, `mixSn=${id}`)).data.obj;
+    const plantData = (await this.request.post('/device/getPlantTotalData', `plantId=${plantId}`)).data.obj;
+    if (statusData) {
+    // if (statusData && totalData && plantData) {
+      return {
+        power: parseFloat(statusData.pLocalLoad),
+        solarPower: parseFloat(statusData.pPv1),
+        batteryPower: 0,
+        gridPower: parseFloat(statusData.pactouser),
+        energy: 0,
+        solarEnergy: 0,
+        batteryEnergy: 0,
+        gridEnergy: 0,
+        monthlySavings: 0,
+        totalSavings: 0,
+        batterySOC: parseFloat(statusData.SOC)
       }
     }
   }


### PR DESCRIPTION
SPH inverters seems to be using different API endpoints. This change adds support for a new type (mix) which is used by SPH. 